### PR TITLE
Fix bug calling own render with old signature

### DIFF
--- a/issuePane.js
+++ b/issuePane.js
@@ -94,7 +94,7 @@ module.exports = {
     var thisPane = this
     var rerender = function (div) {
       var parent = div.parentNode
-      var div2 = thisPane.render(subject, dom)
+      var div2 = thisPane.render(subject, context)
       parent.replaceChild(div2, div)
     }
 


### PR DESCRIPTION
`      var div2 = thisPane.render(subject, context)
`
where context was dom
