### PR TITLE
Small UI updates closing #25 and #40

### DIFF
--- a/issuePane.js
+++ b/issuePane.js
@@ -22,7 +22,7 @@ const widgets = UI.widgets
 // const TRACKER_ICON = UI.icons.iconBase + 'noun_list_638112'
 // const TASK_ICON = UI.icons.iconBase + 'noun_17020.svg'
 
-const OVERFLOW_STYLE = 'position: fixed; top: 1.51em; right: 2em; left: 2em; bottom:1.5em; border: 0.1em grey; overflow: scroll;'
+const OVERFLOW_STYLE = 'position: fixed; z-index: 100; top: 1.51em; right: 2em; left: 2em; bottom:1.5em; border: 0.1em grey; overflow: scroll;'
 export default {
   icon: UI.icons.iconBase + 'noun_122196.svg', // was: js/panes/issue/tbl-bug-22.png
   // noun_list_638112 is a checklist document

--- a/trackerSettingsForm.js
+++ b/trackerSettingsForm.js
@@ -31,7 +31,7 @@ export const trackerSettingsFormText = `
       [   a ui:Comment;  ui:contents """You can optionally sort issues using (one or more) classification systems"""@en ]
 
 
-      [ a ui:Choice;  ui:canMintNew true;  ui:use core:ClassificationForm;
+      [ a ui:Multiple;  ui:canMintNew true;  ui:part core:ClassificationForm;
           ui:property  wf:issueCategory; ui:label "Sort them into which category?"; ui:from rdfs:Class ]
 
       [ a :BooleanField;

--- a/trackerSettingsForm.ttl
+++ b/trackerSettingsForm.ttl
@@ -30,7 +30,7 @@
       [   a ui:Comment;  ui:contents """You can optionally sort issues using (one or more) classification systems"""@en ]
 
 
-      [ a ui:Choice;  ui:canMintNew true;  ui:use core:ClassificationForm;
+      [ a ui:Multiple;  ui:canMintNew true;  ui:part core:ClassificationForm;
           ui:property  wf:issueCategory; ui:label "Sort them into which category?"; ui:from rdfs:Class ]
 
       [ a :BooleanField;


### PR DESCRIPTION
Closes #25 where tabs were showing through the issue view. This is solved by specifying z-index for the overlay. See comment on the issue.

Closes #40 where existing multiple wf:issueCategory were deleted and replaced when using the settings. This is fixed by using ui:Multiple instead.

Both changes were verified using the solid pane tester.